### PR TITLE
HotFix(US-06): Adición correcta del import MultipleSelectionTestResponse.

### DIFF
--- a/backend/src/modules/deepseek/domain/ports/deepseek.port.ts
+++ b/backend/src/modules/deepseek/domain/ports/deepseek.port.ts
@@ -4,6 +4,7 @@ import {
   DoubleOptionResponse,
   MultipleSelectionResponse,
   QuestionResponse,
+  MultipleSelectionTestResponse,
 } from './response';
 
 export interface DeepseekPort {

--- a/backend/src/modules/deepseek/infrastructure/ds.adapter.ts
+++ b/backend/src/modules/deepseek/infrastructure/ds.adapter.ts
@@ -9,7 +9,7 @@ import {
   QuestionResponse,
   MultipleSelectionResponse,
   DoubleOptionResponse,
-
+  MultipleSelectionTestResponse,
 } from '../domain/ports/response';
 
 @Injectable()
@@ -270,5 +270,4 @@ export class DsAdapter implements DeepseekPort {
       throw new Error('Error generating multiple selection and question');
     }
   }
-
 }


### PR DESCRIPTION
# Descripción 
Se implementó el import MultipleSelectionTestResponse para arreglo del levantamiento de la parte de backend en los archivos deepseek.port.ts y ds.adapter.ts en el hexagono de deepseek. 