### PR TITLE
US-5.4 Fix Mejora en la animacion de el modulo de examenes

### DIFF
--- a/client/src/components/tests/TestRunner.tsx
+++ b/client/src/components/tests/TestRunner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Spin, Alert, Button } from "antd";
+import { Alert, Button, theme } from "antd";
 import TestQuestion from "./TestQuestion";
 import TrueOrFalseQuestion from "./TrueOrFalseQuestion";
 
@@ -17,6 +17,7 @@ interface Props {
 }
 
 export default function TestRunner({ onAnswered }: Props): JSX.Element {
+  const { token } = theme.useToken();
   const [item, setItem] = useState<ServerResp | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -64,8 +65,51 @@ export default function TestRunner({ onAnswered }: Props): JSX.Element {
 
   if (loading) {
     return (
-      <div style={{ display: "flex", justifyContent: "center", padding: 24 }}>
-        <Spin />
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "60vh",
+          padding: 32,
+          color: token.colorText,
+          background: "transparent",
+        }}
+      >
+        <h2 style={{ fontSize: 24, fontWeight: 600, marginBottom: 24 }}>
+          Generando pregunta...
+        </h2>
+        <div
+          style={{
+            width: "100%",
+            maxWidth: 400,
+            height: 10,
+            background: token.colorBorderSecondary,
+            borderRadius: 5,
+            overflow: "hidden",
+            position: "relative",
+          }}
+        >
+          <div
+            style={{
+              height: "100%",
+              width: "40%",
+              background: token.colorPrimary,
+              position: "absolute",
+              animation: "loadingBar 1.5s infinite linear",
+            }}
+          />
+        </div>
+        <style>
+          {`
+            @keyframes loadingBar {
+              0% { left: -40%; }
+              50% { left: 30%; }
+              100% { left: 100%; }
+            }
+          `}
+        </style>
       </div>
     );
   }


### PR DESCRIPTION
### Descripción
- Se modificó el componente **InterviewChat** para integrar la apertura del modal de selección de dificultad antes de iniciar la entrevista.
- Se añadió el nuevo componente **InterviewModal** para permitir al usuario seleccionar la dificultad (número de preguntas) antes de comenzar.
- Se añadió el hook **useStudentInterview** con la lógica para manejar:
  - Apertura y cierre del modal.
  - Selección de dificultad.
  - Control de número de preguntas y tipo de pregunta.
  - Avance entre preguntas.
- Se movió el componente **InterviewFeedbackModal** dentro de `InterviewChat` para mostrar el feedback al finalizar la entrevista.
- Se actualizó el componente **TestRunner** para mejorar la animación de carga, eliminando el spinner y aplicando un diseño más limpio con barra animada y soporte de modo oscuro.

### Cambios principales
- **InterviewChat**:
  - Renderiza `InterviewModal` y utiliza `useStudentInterview` para iniciar el flujo de entrevista.
  - Integra `InterviewFeedbackModal` directamente para mostrar resultados al finalizar.
- **Nuevo componente**: `InterviewModal` (antes llamado TestModal en versiones previas).
- **Nuevo hook**: `useStudentInterview` para encapsular la lógica del modal y el flujo inicial.
- **TestRunner**: rediseño de la animación de carga con barra animada y colores adaptativos según el tema.

### Motivo
Mejorar la experiencia del usuario permitiendo seleccionar la dificultad antes de iniciar la entrevista, centralizar la lógica de control en un hook reutilizable y ofrecer una animación de carga más atractiva y adaptada al modo oscuro.

### Impacto
- Flujo de entrevista más claro y controlado.
- Código más modular, reutilizable y fácil de mantener.
- Mejor visibilidad del feedback final dentro del mismo componente.
- Animación de carga más moderna y coherente con el tema visual.

<img width="1097" height="640" alt="Captura desde 2025-09-11 18-22-44" src="https://github.com/user-attachments/assets/d868638d-9dff-4451-a8cf-683a362357fe" />
<img width="1097" height="640" alt="Captura desde 2025-09-11 18-22-39" src="https://github.com/user-attachments/assets/671dfbd8-3021-4b7a-ada7-64b9a7a801ea" />
