### PR TITLE
Fix(US-5.5):Cambio de checkbox por radio en teoric question y multiple question

### DIFF
--- a/client/src/components/interview/MultipleQuestion.tsx
+++ b/client/src/components/interview/MultipleQuestion.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Typography, Checkbox, Button, theme } from 'antd';
+import { Typography, Radio, Button, theme } from 'antd';
 import { RightOutlined, CodeOutlined } from '@ant-design/icons';
 import apiClient from '../../api/apiClient';
 import InterviewRunner from './InterviewRunner';
@@ -26,12 +26,12 @@ interface DoubleOptionResponse {
 
 export default function MultipleQuestion({ onNext }: MultipleQuestionProps) {
   const { token } = theme.useToken();
-  const [selectedValues, setSelectedValues] = useState<string[]>([]);
+  const [selectedValue, setSelectedValue] = useState<string>('');
   const [doubleOption, setDoubleOption] = useState<DoubleOptionResponse>();
   const [loading, setLoading] = useState(true);
 
-  const handleCheckboxChange = (values: string[]) => {
-    setSelectedValues(values);
+  const handleRadioChange = (e: any) => {
+    setSelectedValue(e.target.value);
   };
 
   useEffect(() => {
@@ -108,19 +108,19 @@ export default function MultipleQuestion({ onNext }: MultipleQuestionProps) {
           <Paragraph
             style={{
               margin: 0,
-              fontWeight: 500,
+              fontWeight: 600,
               color: token.colorText,
-              fontSize: token.fontSizeLG,
+              fontSize: token.fontSizeXL,
               textAlign: 'center',
-              lineHeight: 1.4,
+              lineHeight: 1.6,
             }}
           >
             {doubleOption.question}
           </Paragraph>
 
-          <Checkbox.Group
-            onChange={(vals) => handleCheckboxChange(vals as string[])}
-            value={selectedValues}
+          <Radio.Group
+            onChange={handleRadioChange}
+            value={selectedValue}
             style={{
               width: '100%',
               display: 'flex',
@@ -131,9 +131,9 @@ export default function MultipleQuestion({ onNext }: MultipleQuestionProps) {
             }}
           >
             {doubleOption.options.map((opt, i) => {
-              const selected = selectedValues.includes(opt.answer);
+              const selected = selectedValue === opt.answer;
               return (
-                <Checkbox key={i} value={opt.answer} style={{ margin: 0 }}>
+                <Radio key={i} value={opt.answer} style={{ margin: 0 }}>
                   <div
                     style={{
                       width: 320,
@@ -164,26 +164,29 @@ export default function MultipleQuestion({ onNext }: MultipleQuestionProps) {
                     <pre
                       style={{
                         backgroundColor: token.colorFillTertiary,
-                        padding: token.paddingSM,
+                        padding: `${token.paddingSM}px ${token.paddingMD}px`,
                         borderRadius: token.borderRadiusSM,
                         fontSize: token.fontSizeSM,
                         overflowX: 'auto',
                         margin: 0,
                         color: token.colorText,
                         lineHeight: 1.5,
+                        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word',
                       }}
                     >
                       {opt.answer}
                     </pre>
                   </div>
-                </Checkbox>
+                </Radio>
               );
             })}
-          </Checkbox.Group>
+          </Radio.Group>
         </div>
       </div>
 
-      {selectedValues.length > 0 && (
+      {selectedValue && (
         <div
           style={{
             width: WIDTH,

--- a/client/src/components/interview/TeoricQuestion.tsx
+++ b/client/src/components/interview/TeoricQuestion.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Checkbox, Button, Typography, theme } from 'antd';
+import { Radio, Button, Typography, theme } from 'antd';
 import { RightOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import apiClient from '../../api/apiClient';
 import InterviewRunner from './InterviewRunner';
@@ -22,7 +22,7 @@ interface MultipleSelectionResponse {
 
 export default function TeoricQuestion({ onNext }: TeoricQuestionProps) {
   const { token } = theme.useToken();
-  const [selectedValues, setSelectedValues] = useState<string[]>([]);
+  const [selectedValue, setSelectedValue] = useState<string>('');
   const [mulOption, setMulOption] = useState<MultipleSelectionResponse>();
   const [loading, setLoading] = useState(true);
 
@@ -100,17 +100,17 @@ export default function TeoricQuestion({ onNext }: TeoricQuestionProps) {
           <Paragraph
             style={{
               margin: 0,
-              fontWeight: 500,
+              fontWeight: 600,
               color: token.colorText,
-              fontSize: token.fontSizeLG,
+              fontSize: token.fontSizeXL,
               textAlign: 'center',
-              lineHeight: 1.4,
+              lineHeight: 1.6,
             }}
           >
             {mulOption.question}
           </Paragraph>
 
-          <Checkbox.Group
+          <Radio.Group
             style={{
               width: '100%',
               display: 'flex',
@@ -118,20 +118,20 @@ export default function TeoricQuestion({ onNext }: TeoricQuestionProps) {
               gap: token.marginMD,
               justifyContent: 'center',
             }}
-            value={selectedValues}
-            onChange={(checked) => setSelectedValues(checked as string[])}
+            value={selectedValue}
+            onChange={(e) => setSelectedValue(e.target.value)}
           >
             {mulOption.options.map((option, i) => {
-              const selected = selectedValues.includes(option);
+              const selected = selectedValue === option;
               return (
-                <Checkbox key={i} value={option} style={{ margin: 0 }}>
+                <Radio key={i} value={option} style={{ margin: 0 }}>
                   <div
                     style={{
                       width: 320,
                       padding: token.paddingMD,
                       borderRadius: token.borderRadiusLG,
                       border: `2px solid ${selected ? token.colorPrimary : token.colorBorderSecondary}`,
-                      backgroundColor: selected ? token.colorPrimaryBg : token.colorBgContainer,
+                      backgroundColor: token.colorBgContainer,
                       boxShadow: selected
                         ? `0 4px 12px ${token.colorPrimary}33`
                         : token.boxShadowSecondary,
@@ -151,14 +151,14 @@ export default function TeoricQuestion({ onNext }: TeoricQuestionProps) {
                       {option}
                     </Paragraph>
                   </div>
-                </Checkbox>
+                </Radio>
               );
             })}
-          </Checkbox.Group>
+          </Radio.Group>
         </div>
       </div>
 
-      {selectedValues.length > 0 && (
+      {selectedValue && (
         <div
           style={{
             width: WIDTH,


### PR DESCRIPTION
**Descripción del PR**

Este PR actualiza y mejora los componentes **MultipleQuestion** y **TeoricQuestion**.

**Cambios realizados:**
1. Sustitución de `Checkbox.Group` por `Radio.Group` para permitir selección única en ambos componentes.
2. Aumento del tamaño y peso tipográfico de la pregunta (`fontSize: token.fontSizeXL`, `fontWeight: 600`, `lineHeight: 1.6`) para mejorar la legibilidad.
3. Eliminación de colores hardcodeados, utilizando únicamente valores de `theme.token` para garantizar compatibilidad con temas claro/oscuro.
4. Mejora visual de las opciones, con bordes, sombras y transiciones consistentes.
5. Ajuste del bloque de código en **MultipleQuestion** para mayor claridad:
   - Tipografía monoespaciada.
   - Mejor contraste y espaciado.
   - Scroll horizontal suave para líneas largas.
   - Eliminación de contenedores tipo “card” innecesarios.
6. Botón "Siguiente Pregunta" ubicado fuera del contenedor principal y alineado a la derecha, manteniendo consistencia con otros componentes.

**Objetivo:**
Unificar la experiencia visual y de interacción entre ambos componentes, mejorar la legibilidad del contenido y asegurar que todos los estilos se adapten automáticamente a cambios de tema mediante `theme.token`.

<img width="1092" height="577" alt="Captura desde 2025-09-12 22-27-31" src="https://github.com/user-attachments/assets/6447017b-eb24-44f3-8951-c0096829fc74" />
<img width="1092" height="577" alt="Captura desde 2025-09-12 22-27-26" src="https://github.com/user-attachments/assets/ba6d5b7e-2744-46ef-8877-1ae0146013f6" />
<img width="1092" height="577" alt="Captura desde 2025-09-12 22-26-49" src="https://github.com/user-attachments/assets/06ca4f5d-8335-4aa0-a424-dfae9edbc1d8" />
<img width="1092" height="577" alt="Captura desde 2025-09-12 22-26-45" src="https://github.com/user-attachments/assets/8f80f6f2-9985-4aa4-8648-5895eed9c1f9" />

