### PR TITLE
Fix(US-5.5)Correccion bug de entrevistas

### DIFF
--- a/client/src/components/interview/MultipleQuestion.tsx
+++ b/client/src/components/interview/MultipleQuestion.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { Typography, Radio, Button, theme } from 'antd';
 import { RightOutlined, CodeOutlined } from '@ant-design/icons';
 import apiClient from '../../api/apiClient';
@@ -29,12 +29,15 @@ export default function MultipleQuestion({ onNext }: MultipleQuestionProps) {
   const [selectedValue, setSelectedValue] = useState<string>('');
   const [doubleOption, setDoubleOption] = useState<DoubleOptionResponse>();
   const [loading, setLoading] = useState(true);
+  const hasFetched = useRef(false);
 
   const handleRadioChange = (e: any) => {
     setSelectedValue(e.target.value);
   };
 
   useEffect(() => {
+    if (hasFetched.current) return;
+    hasFetched.current = true;
     fetchQuestion();
   }, []);
 

--- a/client/src/components/interview/TeoricQuestion.tsx
+++ b/client/src/components/interview/TeoricQuestion.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { Radio, Button, Typography, theme } from 'antd';
 import { RightOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import apiClient from '../../api/apiClient';
@@ -25,8 +25,11 @@ export default function TeoricQuestion({ onNext }: TeoricQuestionProps) {
   const [selectedValue, setSelectedValue] = useState<string>('');
   const [mulOption, setMulOption] = useState<MultipleSelectionResponse>();
   const [loading, setLoading] = useState(true);
+  const hasFetched = useRef(false);
 
   useEffect(() => {
+    if (hasFetched.current) return;
+    hasFetched.current = true;
     fetchQuestion();
   }, []);
 


### PR DESCRIPTION
**Descripción del cambio**

Se corrigió un bug que provocaba que los componentes **MultipleQuestion** y **TeoricQuestion** realizaran dos solicitudes a la API en modo desarrollo debido al doble montaje causado por React Strict Mode.

**Solución implementada:**
- Se agregó un control mediante `useRef` (`hasFetched`) para asegurar que la función `fetchQuestion()` solo se ejecute una vez por montaje real del componente.
- Esto evita solicitudes duplicadas en desarrollo sin afectar el comportamiento en producción.

**Impacto:**
- Reducción de llamadas innecesarias a la API.
- Mejora en el rendimiento y en la depuración durante el desarrollo.
- Comportamiento consistente entre entornos de desarrollo y producción.
