### PR TITLE
(US-6.2)Feat Implementacion de timer en modulo de examenes

### DIFF
--- a/client/src/components/tests/TestSummaryModal.tsx
+++ b/client/src/components/tests/TestSummaryModal.tsx
@@ -25,10 +25,15 @@ export default function TestSummaryModal({
     () => (questionCount > 0 ? Math.round((correctAnswers / questionCount) * 100) : 0),
     [correctAnswers, questionCount]
   );
-  const formattedTime = useMemo(
-    () => (timeTaken ? new Date(timeTaken).toISOString().substring(14, 19) : "00:00"),
-    [timeTaken]
-  );
+
+  const formattedTime = useMemo(() => {
+    if (!timeTaken || timeTaken <= 0) return "00:00";
+    const totalSeconds = Math.floor(timeTaken / 1000);
+    const minutes = String(Math.floor(totalSeconds / 60)).padStart(2, "0");
+    const seconds = String(totalSeconds % 60).padStart(2, "0");
+    return `${minutes}:${seconds}`;
+  }, [timeTaken]);
+
   const results = useMemo(
     () =>
       answers.map((correct, index) => ({
@@ -65,9 +70,9 @@ export default function TestSummaryModal({
           <Col xs={24} md={16}>
             <div
               style={{
-                maxHeight: 250, 
+                maxHeight: 250,
                 overflowY: "auto",
-                paddingRight: 4, 
+                paddingRight: 4,
               }}
             >
               <List
@@ -109,3 +114,4 @@ export default function TestSummaryModal({
     </CustomModal>
   );
 }
+

--- a/client/src/components/tests/Timer.tsx
+++ b/client/src/components/tests/Timer.tsx
@@ -1,43 +1,23 @@
-import { useEffect, useState } from "react";
 import { theme } from "antd";
-import { useNavigate } from "react-router-dom";
 
-type Props = { questionCount?: number; onTimeUp?: () => void };
+type Props = {
+  timeLeft: number;
+  totalTime: number;
+};
 
-export function TestTimer({ questionCount = 1, onTimeUp }: Props) {
+export default function TimerDisplay({ timeLeft, totalTime }: Props) {
   const { token } = theme.useToken();
-  const navigate = useNavigate();
-  const totalTime = questionCount * 30;
-  const [timeLeft, setTimeLeft] = useState(totalTime);
-
-  useEffect(() => {
-    setTimeLeft(totalTime);
-  }, [totalTime]);
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setTimeLeft(prev => {
-        if (prev <= 1) {
-          clearInterval(timer);
-          if (onTimeUp) onTimeUp();
-          navigate("/reinforcement");
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-    return () => clearInterval(timer);
-  }, [onTimeUp, navigate]);
-
-  const minutes = String(Math.floor(timeLeft / 60)).padStart(2, "0");
-  const seconds = String(timeLeft % 60).padStart(2, "0");
-  const isDanger = timeLeft <= 10;
+  const isDanger = timeLeft <= 10 && timeLeft > 0;
+  const timeUsed = totalTime - timeLeft;
+  const displayTime = timeLeft > 0 ? timeLeft : timeUsed;
+  const minutes = String(Math.floor(displayTime / 60)).padStart(2, "0");
+  const seconds = String(displayTime % 60).padStart(2, "0");
 
   return (
     <div
       style={{
         position: "fixed",
-        bottom: 24,
+        top: 24,
         right: 24,
         zIndex: 1000,
         display: "flex",
@@ -48,23 +28,23 @@ export function TestTimer({ questionCount = 1, onTimeUp }: Props) {
         fontWeight: 600,
         padding: "10px 18px",
         borderRadius: token.borderRadiusLG,
-        border: `1px solid ${isDanger ? token.colorErrorBorder : token.colorBorderSecondary}`,
-        background: `${token.colorBgElevated}cc`,
+        border: `1px solid ${isDanger ? token.colorWhite : token.colorBorderSecondary}`,
+        background: isDanger ? `${token.colorError}cc` : `${token.colorBgElevated}cc`,
         backdropFilter: "blur(8px)",
-        color: isDanger ? token.colorError : token.colorText,
+        color: isDanger ? token.colorWhite : token.colorText,
         boxShadow: token.boxShadowSecondary,
         transition: "all 0.3s ease",
-        animation: isDanger ? "pulse 1s infinite" : "none"
+        animation: isDanger ? "pulse-red 1s infinite" : "none"
       }}
     >
       <span style={{ fontSize: 18 }}>⏱</span>
       {minutes}:{seconds}
       <style>
         {`
-          @keyframes pulse {
-            0% { opacity: 1; }
-            50% { opacity: 0.6; }
-            100% { opacity: 1; }
+          @keyframes pulse-red {
+            0% { box-shadow: 0 0 0px ${token.colorError}; }
+            50% { box-shadow: 0 0 12px ${token.colorError}; }
+            100% { box-shadow: 0 0 0px ${token.colorError}; }
           }
         `}
       </style>

--- a/client/src/hooks/useStudentTest.ts
+++ b/client/src/hooks/useStudentTest.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 
-export function useStudentTest() {
+export function useStudentTest(onFinish?: () => void) {
   const [isTestModalOpen, setIsTestModalOpen] = useState(false);
   const [questionCount, setQuestionCount] = useState<number>(0);
   const [currentQuestion, setCurrentQuestion] = useState<number>(1);
@@ -8,14 +8,11 @@ export function useStudentTest() {
   const [answers, setAnswers] = useState<boolean[]>([]);
   const [startTime, setStartTime] = useState<number | null>(null);
   const [endTime, setEndTime] = useState<number | null>(null);
+  const [timeLeft, setTimeLeft] = useState<number>(0);
+  const [totalTime, setTotalTime] = useState<number>(0);
 
-  const openTestModal = useCallback(() => {
-    setIsTestModalOpen(true);
-  }, []);
-
-  const closeTestModal = useCallback(() => {
-    setIsTestModalOpen(false);
-  }, []);
+  const openTestModal = useCallback(() => setIsTestModalOpen(true), []);
+  const closeTestModal = useCallback(() => setIsTestModalOpen(false), []);
 
   const randomizeType = useCallback(() => {
     const types: Array<"multiple" | "truefalse"> = ["multiple", "truefalse"];
@@ -23,11 +20,14 @@ export function useStudentTest() {
   }, []);
 
   const startExam = useCallback((count: number) => {
+    const total = count * 30;
     setQuestionCount(count);
     setCurrentQuestion(1);
     setAnswers([]);
     setStartTime(Date.now());
     setEndTime(null);
+    setTotalTime(total);
+    setTimeLeft(total);
     randomizeType();
     setIsTestModalOpen(false);
   }, [randomizeType]);
@@ -36,18 +36,38 @@ export function useStudentTest() {
     setAnswers(prev => [...prev, isCorrect]);
   }, []);
 
+  const finishExam = useCallback(() => {
+    setEndTime(Date.now());
+    if (onFinish) onFinish();
+  }, [onFinish]);
+
   const nextQuestion = useCallback(() => {
     if (currentQuestion < questionCount) {
       setCurrentQuestion(prev => prev + 1);
       randomizeType();
     } else {
-      setEndTime(Date.now());
+      finishExam();
     }
-  }, [currentQuestion, questionCount, randomizeType]);
+  }, [currentQuestion, questionCount, randomizeType, finishExam]);
 
   useEffect(() => {
     openTestModal();
   }, [openTestModal]);
+
+  useEffect(() => {
+    if (totalTime === 0) return;
+    const timer = setInterval(() => {
+      setTimeLeft(prev => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          finishExam();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [totalTime, finishExam]);
 
   return {
     isTestModalOpen,
@@ -57,10 +77,13 @@ export function useStudentTest() {
     answers,
     startTime,
     endTime,
+    timeLeft,
+    totalTime,
     openTestModal,
     closeTestModal,
     startExam,
     nextQuestion,
-    recordAnswer
+    recordAnswer,
+    finishExam
   };
 }

--- a/client/src/pages/reinforcement/test.tsx
+++ b/client/src/pages/reinforcement/test.tsx
@@ -5,9 +5,13 @@ import TestModal from "../../components/tests/TestModal";
 import TestRunner from "../../components/tests/TestRunner";
 import TestSummaryModal from "../../components/tests/TestSummaryModal";
 import { useStudentTest } from "../../hooks/useStudentTest";
+import TimerDisplay from "../../components/tests/Timer";
 
 export default function Test() {
   const navigate = useNavigate();
+  const [isExamStarted, setIsExamStarted] = useState(false);
+  const [showSummary, setShowSummary] = useState(false);
+
   const {
     isTestModalOpen,
     closeTestModal,
@@ -18,11 +22,11 @@ export default function Test() {
     startTime,
     endTime,
     nextQuestion,
-    recordAnswer
-  } = useStudentTest();
-
-  const [isExamStarted, setIsExamStarted] = useState(false);
-  const [showSummary, setShowSummary] = useState(false);
+    recordAnswer,
+    timeLeft,
+    totalTime,
+    finishExam
+  } = useStudentTest(() => setShowSummary(true));
 
   const handleStartExam = (count: number) => {
     startExam(count);
@@ -34,7 +38,7 @@ export default function Test() {
     if (currentQuestion < questionCount) {
       nextQuestion();
     } else {
-      setShowSummary(true);
+      finishExam();
     }
   };
 
@@ -65,13 +69,14 @@ export default function Test() {
           onSelectDifficulty={handleStartExam}
         />
       )}
-
       {isExamStarted && (
-        <div style={{ width: "100%", minHeight: 300 }}>
-          <TestRunner onAnswered={handleNextQuestion} />
-        </div>
+        <>
+          <TimerDisplay timeLeft={timeLeft} totalTime={totalTime} />
+          <div style={{ width: "100%", minHeight: 300 }}>
+            <TestRunner onAnswered={handleNextQuestion} />
+          </div>
+        </>
       )}
-
       {showSummary && (
         <TestSummaryModal
           open={showSummary}


### PR DESCRIPTION
# Resumen de cambios

## Hook: useStudentTest
- Se agregó la función `finishExam()` para fijar `endTime` en todos los casos de finalización del examen (por tiempo o por última pregunta).
- Se modificó `nextQuestion()` para llamar a `finishExam()` cuando se llega a la última pregunta.
- Se ajustó el temporizador (`useEffect`) para que al llegar a 0 llame a `finishExam()` y detenga el conteo.
- Se asegura que `timeLeft` y `totalTime` se inicialicen correctamente al iniciar el examen (`startExam`).

## Página: Test.tsx
- Se reemplazó la lógica de finalización directa (`setShowSummary(true)`) por `finishExam()` para garantizar que `endTime` se fije antes de abrir el modal.
- Se pasa `timeTaken` al `TestSummaryModal` como `endTime - startTime` para que sea un valor estático.
- Se mantiene el `TimerDisplay` mostrando el tiempo restante mientras el examen está activo.

## Componente: TestSummaryModal
- Se cambió el formateo de `timeTaken` para no depender de `Date.toISOString()` y evitar valores incorrectos.
- Se implementó un cálculo manual de minutos y segundos (`mm:ss`) a partir de `timeTaken` en milisegundos.
- Se asegura que si `timeTaken` es `null` o `0`, se muestre `"00:00"`.

## Resultado esperado
- El tiempo mostrado en el modal de resumen es estático y refleja el tiempo real usado en el examen.
- El temporizador se detiene al finalizar el examen, sin seguir contando en el modal.
- El flujo de finalización es consistente tanto si el examen termina por tiempo como por responder la última pregunta.
