### PR TITLE
fix: Campo de dato signature eliminado de las tablas InterviewQuestion y QuizQuestion

### DIFF
--- a/backend/prisma/migrations/20250914214224_remove_signature_field/migration.sql
+++ b/backend/prisma/migrations/20250914214224_remove_signature_field/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `signature` on the `interview_questions` table. All the data in the column will be lost.
+  - You are about to drop the column `signature` on the `quiz_questions` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "public"."interview_questions_signature_key";
+
+-- DropIndex
+DROP INDEX "public"."quiz_questions_signature_key";
+
+-- AlterTable
+ALTER TABLE "public"."interview_questions" DROP COLUMN "signature";
+
+-- AlterTable
+ALTER TABLE "public"."quiz_questions" DROP COLUMN "signature";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -445,7 +445,6 @@ model Enrollment {
    model QuizQuestion {
     id         String   @id @default(uuid())
     classId    String
-    signature  String   @unique
     text       String   @db.Text
     type       String
     options    Json?
@@ -463,7 +462,6 @@ model Enrollment {
   model InterviewQuestion {
     id         String   @id @default(uuid())
     classId    String
-    signature  String   @unique
     text       String   @db.Text
     createdAt  DateTime @default(now())
     lastUsedAt DateTime?


### PR DESCRIPTION
##Descripcion
se elimino campo innecesario de las tablas quiz e interview
## Add 
Se añadió una nueva migración con los las modificaciones en las tablas 
## Delete
No se eliminó ningun archivo o carpeta
## Update
Se modificó el archivo schema.prisma para eliminar el campo signature de los modelos de tabla de quiz e interview.
## Breaking Change
ningun cambio afecta a los modulos de otros grupos ni tablas ya creadas. 